### PR TITLE
Fix detect_clang_version version extraction

### DIFF
--- a/Library/Homebrew/os/mac/xcode.rb
+++ b/Library/Homebrew/os/mac/xcode.rb
@@ -383,7 +383,7 @@ module OS
       sig { returns(T.nilable(String)) }
       def detect_clang_version
         version_output = Utils.popen_read("#{PKG_PATH}/usr/bin/clang", "--version")
-        version_output[/clang-(\d+\.\d+\.\d+(\.\d+)?)/, 1]
+        version_output[/clang-(\d+(\.\d+)+)/, 1]
       end
 
       sig { returns(T.nilable(String)) }


### PR DESCRIPTION
The previous implementation was depending on a fix number of version number segments. Apple has introduced one more tag for the latest CLT version 13.4, which broke the check, leading to a false warning. With this rewritten regex we have a more robust version detection.

- [x] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/HEAD/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/HEAD/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew typecheck` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----
